### PR TITLE
Change doc: correct link to datalakes repository

### DIFF
--- a/docs/guides/bugs.md
+++ b/docs/guides/bugs.md
@@ -1,5 +1,5 @@
 # Reporting other bugs and issues
 
-- To report a bug related to the QA-QC software, create an issue on https://github.com/eawag-surface-waters-research/datalakes-react.git 
+- To report a bug related to the QA-QC software, create an issue on [the datalakes repository](https://github.com/eawag-surface-waters-research/datalakes-react.git)
 - To report a bug related to a specific dataset, create an issue on the git repository of the dataset.
 


### PR DESCRIPTION
## What does this change?

The link to the datalakes repository is now clickable.

## Type of change

- 🐛 Bug fix