### PR TITLE
Add information about mkdocs and the 4 steps of the QA-QC procedure 

### DIFF
--- a/docs/QC.md
+++ b/docs/QC.md
@@ -6,12 +6,22 @@
 
 ## From issue reporting to data curation
 
-The issue can have four different states:
+### Steps
 
-- **Draft**: the issue has been created by the reporter but not reviewed by the data curator/advisor yet. At this stage, the reporter can still edit the issue. The data is still visible in Datalakes to the users.
-- **Confirmed**: the issue has been reviewed and confirmed by the data curator/advisor. The data is masked in Datalakes but remains present in the database.
-- **Resolved**: the issue has been validated by the data curator/advisor. A merge request is created in the instrument repository to permanently remove the data from Datalakes.
-- **Closed**: the issue has been closed after the merge request has been accepted and merged in the instrument repository. The data is permanently removed from Datalakes.
+The QA/QC procedure is divided into the following four steps:
+
+1. **Issue report**: A reporter (i.e., any datalakes user, including the data curator and advisor) detects an QC issue, fills and submits the ["Report Issue" form](guides/reporting.md). The issue is added to the list of issues in the issue form on Datalakes and in the git repository of the dataset. A notification is sent to the data curator/advisor if they have turned on the notifications for the dataset repository on renku. The data is still visible on Datalakes to the users (not masked yet), but a colored box is displayed around the flagged data by clicking on "Show Masked Points" in the Display Options. Information about the issue can be found by moving the mouse on this box. At this stage, the reporter can still edit the issue.
+2. **Issue review**: the data curator/advisor [reviews](guides/management.md) the reported issue. If the issue has been reported by the data curator, the data advisor reviews it (and vice-versa). They check if the issue is valid and can either edit, confirm or delete it. Once the issue is confirmed, the data is masked on Datalakes but remains present in the database (i.e., not masked in Level 2 files). 
+3. **Issue validation**: once an issue is confirmed and masked on Datalakes, the data curator/advisor can either [resolve](guides/management.md)  it, edit it by going back to the non-confirmed issue or delete it. They resolve the issue only if they are satisfied with the masking. Resolving the issue creates a merge request in the instrument repository to permanently mask the data in the datafiles (Level 2). 
+4. **Data reprocessing**: the merge request is accepted and merged in the instrument repository. The events.csv is updated, the data is reprocessed and the issue-related data is permanently masked in the Level 2 files.
+
+### States
+Issue states are displayed in the "Report Issue" form (for authenticated users only). The issue can have four different states based on the steps above:
+
+- **Reported**: the issue has been created by the reporter but not reviewed by the data curator/advisor yet. 
+- **Confirmed**: the issue has been reviewed and confirmed by the data curator/advisor. 
+- **Resolved**: the issue has been validated by the data curator/advisor and a merge request has been created in the instrument repository.
+- **Closed**: the issue has been closed after the merge request has been accepted and merged in the instrument repository. 
 
 ### Sequence diagram
 

--- a/docs/guides/management.md
+++ b/docs/guides/management.md
@@ -15,7 +15,7 @@ If the data curator is logged in with their Renku credentials and has the approp
 
 ## Confirming the issue on Datalakes
 
-The first step of the process for the data curator is to confirm that the issue is valid. As long as the issue has not been confirmed, the data remains visible to the users and the data curator has the oppourtunity to edit the issue if needed. Once the data curator is satisfied that the issue is valid, they can confirm the issue. This will mask the data in Datalakes, meaning that it will no longer be visible to the users. The confirmation can be removed to unmask the data and edit the issue if needed.
+The first step of the process for the data curator is to confirm that the issue is valid. As long as the issue has not been confirmed, the data remains visible to the users and the data curator has the opportunity to edit the issue if needed. Once the data curator is satisfied that the issue is valid, they can confirm the issue. This will mask the data in Datalakes, meaning that it will no longer be visible to the users. The confirmation can be removed to unmask the data and edit the issue if needed.
 
 ## Resolving the issue on Datalakes
 

--- a/docs/guides/management.md
+++ b/docs/guides/management.md
@@ -1,4 +1,4 @@
-# Managing a reported issue in Datalakes
+# Managing a reported QC issue in Datalakes
 
 When an issue is reported, the data curator should be [automatically assigned](assignment.md) to the issue in GitLab. Upon notification, the data curator should manage the issue directly on Datalakes, using the issue management popup
 

--- a/docs/guides/reporting.md
+++ b/docs/guides/reporting.md
@@ -16,3 +16,5 @@ To report an issue you encountered in a LéXPLORE dataset in the development ver
     1. Provide a clear and concise title for your issue.
     2. Describe the issue in detail.
     3. Specify the parameters affected by the issue.
+    4. Submit the report.
+4. Check that the issue has been correctly reported. A colored box is displayed around the flagged data by clicking on "Show Masked Points" in the Display Options. Information about the issue can be found by moving the mouse on this box. Edit the issue if needed.

--- a/docs/guides/updating_docs.md
+++ b/docs/guides/updating_docs.md
@@ -5,7 +5,12 @@ To update the documentation, follow these steps:
 1. Make sure you have the latest version of the documentation repository.
 2. Fork the repository on GitHub.
 3. Create a new branch for your changes.
-4. Make your changes to the documentation files. If you create a new page in guides, add the name of the new page to `guides/index.md` and to`mkdocs.yml` (section `nav`).
-5. Test your changes locally to ensure they work as expected, using `mkdocs serve`.
+4. Make your changes to the documentation files, either on GitHub or locally after cloning the forked repository (recommended). If you create a new page in guides, add the name of the new page to `guides/index.md` and to`mkdocs.yml` (section `nav`).
+5. Test your changes locally to ensure they work as expected: 
+    1. install the python package mkdocs with `pip install mkdocs`
+    2. in the python console, move to the local repository of the documentation and run `mkdocs serve`
+    3. copy-paste the http link from the console to a web browser to visualize the website
+    4. keep mkdocs running while making changes to the documentation (changes are automatically made to the website preview on the browser).
 6. Commit your changes and push the branch to the remote repository.
 7. Create a pull request to merge your changes into the main branch of the documentation repository.
+8. Before making any additional change locally, make sure to (1) synchronize the forked repository with the original one and (2) pull the remote branch to the local repository. 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,9 +53,9 @@ nav:
   - 'Guides':
     - 'Overview': guides/index.md
     - 'Reporting a QC issue': guides/reporting.md
-    - 'Managing issues': guides/management.md
+    - 'Managing QC issues': guides/management.md
     - 'Assigning a data curator/advisor': guides/assignment.md
-    - 'Merging issues': guides/merging.md
+    - 'Merging QC issues': guides/merging.md
     - 'Modifying the automated L1 QA': guides/QA_json.md
     - 'Managing roles in the instrument repository': guides/roles.md
     - 'Reporting missing feature or code issue': guides/bugs.md


### PR DESCRIPTION
## What does this change?

- More information on how to install and use mkdocs in the guide updating_doc.md
- Clearer description of the 4 steps of the QA-QC procedure in QC.md, with some additions to the reporting and management guides

## Type of change

 - [x] 📝 Documentation update