### PR TITLE
[DOCS] Add profiles instructions

### DIFF
--- a/docs/guides/assignment.md
+++ b/docs/guides/assignment.md
@@ -1,6 +1,6 @@
 # Assigning a data curator/advisor to a dataset (tentative)
 
-To assign a data curator to a dataset in the development version of Datalakes, the following steps must be followed:
+To assign a data curator to a dataset in Datalakes, the following steps must be followed:
 
 - give a `dev` or `maintainer` role to the data curator in the repository
 - if no issue template exists, create an issue template

--- a/docs/guides/reporting.md
+++ b/docs/guides/reporting.md
@@ -1,6 +1,13 @@
 # Reporting a quality-control issue
 
-To report an issue you encountered in a LéXPLORE dataset in datalakes, follow these steps below. In the following, we assume that the user has logged into Datalakes with their credentials and therefore has access to the detailed issue submission form
+To report an issue you encountered in a LéXPLORE dataset on Datalakes, follow these steps below. In the following, we assume that the user has logged into Datalakes with their credentials and therefore has access to the detailed issue submission form
+
+<!-- prettier-ignore-start -->
+
+!!! warning
+    For datasets including profiles (e.g. [CTD Profiles](https://www.datalakes-eawag.ch/datadetail/674) or [Idronaut Profiles](https://www.datalakes-eawag.ch/datadetail/667)), you may select a time range for which the correction should be applied. To do so, in the right tab, head to the end of the time range, check "Keep previously plotted line" and use the left arrow to move to the start of the time range, adding all profiles to the plots. The issue will then be reported for the time range and will affect all profiles within the time range.
+
+<!-- prettier-ignore-end -->
 
 1. Activate the brush mode (Ctrl + click) and select the area of interest in the dataset
 2. Click on the "Report Issue" button below the dataset view, on the right side.

--- a/docs/guides/reporting.md
+++ b/docs/guides/reporting.md
@@ -1,13 +1,6 @@
 # Reporting a quality-control issue
 
-To report an issue you encountered in a LéXPLORE dataset in the development version of datalakes, follow these steps below. In the following, we assume that the user has logged into the development version of Datalakes with their Renku credentials and therefore has access to the detailed issue submission form
-
-<!-- prettier-ignore-start -->
-
-!!! warning
-    If you logged in with your GitHub or GitLab account, you will only have access to the simplified form.
-
-<!-- prettier-ignore-end -->
+To report an issue you encountered in a LéXPLORE dataset in datalakes, follow these steps below. In the following, we assume that the user has logged into Datalakes with their credentials and therefore has access to the detailed issue submission form
 
 1. Activate the brush mode (Ctrl + click) and select the area of interest in the dataset
 2. Click on the "Report Issue" button below the dataset view, on the right side.

--- a/docs/guides/reporting.md
+++ b/docs/guides/reporting.md
@@ -5,7 +5,7 @@ To report an issue you encountered in a LéXPLORE dataset on Datalakes, follow t
 <!-- prettier-ignore-start -->
 
 !!! warning
-    For datasets including profiles (e.g. [CTD Profiles](https://www.datalakes-eawag.ch/datadetail/674) or [Idronaut Profiles](https://www.datalakes-eawag.ch/datadetail/667)), you may select a time range for which the correction should be applied. To do so, in the right tab, head to the end of the time range, check "Keep previously plotted line" and use the left arrow to move to the start of the time range, adding all profiles to the plots. The issue will then be reported for the time range and will affect all profiles within the time range.
+    For datasets including profiles (e.g. [CTD Profiles](https://www.datalakes-eawag.ch/datadetail/674) or [Idronaut Profiles](https://www.datalakes-eawag.ch/datadetail/667)), you may select a time range for which the correction should be applied. To do so, in the right tab, head to the end of the time range, check "Keep previously plotted line" and use the left arrow to move to the start of the time range, adding all profiles to the plots. The issue will then be reported for the time range and will affect all profiles within the time range. Additionally, if one of the dimensions is Depth, the depth range will be pre-filled in the Sensor Depths field, with the selected area in the issue form.
 
 <!-- prettier-ignore-end -->
 


### PR DESCRIPTION
## What does this change?

This PR adds instructions regarding how to report an issue for a profile dataset for multiple timepoints simultaneously, following [#58](https://github.com/eawag-surface-waters-research/datalakes-react/pull/58#event-22286284238)

## Why is this needed?

<!-- Explain the problem this solves or the improvement this brings -->

## Type of change

Please check the type that applies:

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation update
- [ ] 🎨 Design/UI improvement
- [ ] 🔧 Configuration change
- [ ] 🧹 Code cleanup

## How to test this

<!-- How can reviewers verify this works? -->

- [x] I've tested this change locally
- [ ] Steps to test: (describe if needed)

## Screenshots (if applicable)

<!-- For UI changes, drag & drop screenshots here -->

## Related issues

- Closes #
- Related to #
